### PR TITLE
Implement basic DNS enumeration module

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"recon-bot/recon"
 	"regexp"
 )
 
@@ -52,4 +53,7 @@ func main() {
 	fmt.Println("#      Herramienta de Reconocimiento    #")
 	fmt.Println("#########################################")
 	fmt.Printf("[+] Iniciando reconocimiento en: %s\n", *domain)
+
+	// Obtener información de DNS
+	recon.GetDNSInfo(*domain)
 }

--- a/recon/dns.go
+++ b/recon/dns.go
@@ -1,0 +1,33 @@
+package recon
+
+import (
+	"fmt"
+	"net"
+)
+
+// GetDNSInfo busca y muestra información básica de DNS para un dominio dado.
+func GetDNSInfo(domain string) {
+	fmt.Printf("\n[*] Extrayendo información de DNS para: %s\n", domain)
+
+	// Buscar direcciones IP
+	ips, err := net.LookupIP(domain)
+	if err != nil {
+		fmt.Printf("[-] Error al buscar IPs: %v\n", err)
+	} else {
+		fmt.Println("[+] Direcciones IP:")
+		for _, ip := range ips {
+			fmt.Printf("\t- %s\n", ip.String())
+		}
+	}
+
+	// Buscar Servidores de Nombres (NS)
+	nss, err := net.LookupNS(domain)
+	if err != nil {
+		fmt.Printf("[-] Error al buscar Servidores de Nombres: %v\n", err)
+	} else {
+		fmt.Println("[+] Servidores de Nombres (NS):")
+		for _, ns := range nss {
+			fmt.Printf("\t- %s\n", ns.Host)
+		}
+	}
+}


### PR DESCRIPTION
This change implements a basic DNS enumeration module for the recon-bot. It includes:
- A new `recon` package located in the `recon/` directory.
- An exported `GetDNSInfo` function in `recon/dns.go` that retrieves and prints IP addresses and Name Servers (NS) for a given domain using Go's standard `net` package.
- Integration in `main.go` to call the new DNS enumeration logic after the initial validation and banner display.
- Professional console output formatting using bullet points and tabs.

Fixes #3

---
*PR created automatically by Jules for task [1580905348993009174](https://jules.google.com/task/1580905348993009174) started by @Villata-dev*